### PR TITLE
refactor(usecases): Simplify the main pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ project. These are:
 * __Extract Metadata__ - This a description of the data to be extracted from a
   data source. An extract metadata also defines how data is extracted from a
   data source.
-* __Upload Metadat*__ - This describes data that has been extracted and how
+* __Upload Metadata__ - This describes data that has been extracted and how
   it's packaged for uploading to the remote server. Each upload metadata is
   always associated with a given *extract metadata*.
 

--- a/app/use_cases/fetch_metadata.py
+++ b/app/use_cases/fetch_metadata.py
@@ -1,6 +1,6 @@
-from itertools import chain, groupby, product
+from itertools import chain
 from logging import getLogger
-from typing import Iterable, Mapping, Sequence, Tuple
+from typing import Iterable, Mapping, Sequence
 
 from app.core import (
     DataSource,
@@ -9,29 +9,28 @@ from app.core import (
     Task,
     Transport,
 )
-from app.lib import ConcurrentExecutor, Consumer
+from app.lib import ConcurrentExecutor
 
 # =============================================================================
 # CONSTANTS
 # =============================================================================
 
+
 _LOGGER = getLogger(__name__)
 
 
 # =============================================================================
-# TASKS
+# HELPER TASKS
 # =============================================================================
 
 
-class DoFetchDataSourceTypeSources(
-    Task[DataSourceType, Mapping[str, DataSource]]
-):
+class DoFetchDataSourceTypeSources(Task[DataSourceType, Sequence[DataSource]]):
     """Fetches all the data sources of a given data source type."""
 
     def __init__(self, data_source_type: DataSourceType):
         self._data_source_type: DataSourceType = data_source_type
 
-    def execute(self, an_input: Transport) -> Mapping[str, DataSource]:
+    def execute(self, an_input: Transport) -> Sequence[DataSource]:
         _LOGGER.info(
             'Fetching data sources for data source type="%s".',
             str(self._data_source_type),
@@ -43,38 +42,38 @@ class DoFetchDataSourceTypeSources(
             _data_source.id: _data_source for _data_source in data_sources
         }
         self._data_source_type.data_sources = data_source_type_sources
-        return data_source_type_sources
+        return data_sources
 
 
-class DoFetchDataSourceExtracts(
-    Task[DataSource, Mapping[str, ExtractMetadata]]
-):
+class DoFetchDataSourceExtracts(Task[DataSource, Sequence[ExtractMetadata]]):
     """Fetch all the extract metadata of a given data source."""
 
-    def __init__(
-        self, data_source_type: DataSourceType, data_source: DataSource
-    ):
-        self._data_source_type: DataSourceType = data_source_type
+    def __init__(self, data_source: DataSource):
         self._data_source: DataSource = data_source
 
-    def execute(self, an_input: Transport) -> Mapping[str, ExtractMetadata]:
+    def execute(self, an_input: Transport) -> Sequence[ExtractMetadata]:
         _LOGGER.info(
             'Fetching extract metadata for data source="%s".',
             str(self._data_source),
         )
         extracts: Sequence[ExtractMetadata]
         extracts = an_input.fetch_data_source_extracts(
-            data_source_type=self._data_source_type,
+            data_source_type=self._data_source.data_source_type,
             data_source=self._data_source,
         )
         data_source_extracts: Mapping[str, ExtractMetadata] = {
-            _k: next(_v) for _k, _v in groupby(extracts, lambda _e: _e.id)
+            _extract.id: _extract for _extract in extracts
         }
         self._data_source.extract_metadata = data_source_extracts
-        return data_source_extracts
+        return extracts
 
 
-class FetchDataSources(Consumer[Sequence[DataSourceType]]):
+# =============================================================================
+# MAIN TASKS
+# =============================================================================
+
+
+class FetchDataSources(Task[Sequence[DataSourceType], Sequence[DataSource]]):
     """
     Fetch all the :class:`data sources <DataSource>` for the given
     :class:`data source types <DataSourceType>`.
@@ -82,16 +81,19 @@ class FetchDataSources(Consumer[Sequence[DataSourceType]]):
 
     def __init__(self, transport: Transport):
         self._transport: Transport = transport
-        super().__init__(self._consume)
 
-    def _consume(self, an_input: Sequence[DataSourceType]) -> None:
+    def execute(
+        self, an_input: Sequence[DataSourceType]
+    ) -> Sequence[DataSource]:
         _LOGGER.info("Fetching data sources.")
         executor: ConcurrentExecutor[
-            Transport, Sequence[Mapping[str, DataSource]]
+            Transport, Sequence[Sequence[DataSource]]
         ] = ConcurrentExecutor(
             *self._data_source_types_to_tasks(an_input), initial_value=list()
         )
-        executor(self._transport)  # noqa
+        data_sources: Sequence[Sequence[DataSource]]
+        data_sources = executor(self._transport)  # noqa
+        return tuple(chain.from_iterable(data_sources))
 
     @staticmethod
     def _data_source_types_to_tasks(
@@ -107,7 +109,9 @@ class FetchDataSources(Consumer[Sequence[DataSourceType]]):
         )
 
 
-class FetchExtractMetadata(Consumer[Sequence[DataSourceType]]):
+class FetchExtractMetadata(
+    Task[Sequence[DataSource], Sequence[ExtractMetadata]]
+):
     """
     Fetch all :class:`extract metadata <ExtractMetadata>` for the given
     :class:`data sources <DataSource>`.
@@ -115,37 +119,28 @@ class FetchExtractMetadata(Consumer[Sequence[DataSourceType]]):
 
     def __init__(self, transport: Transport):
         self._transport: Transport = transport
-        super().__init__(self._consume)
+        super().__init__()
 
-    def _consume(self, an_input: Sequence[DataSourceType]) -> None:
+    def execute(
+        self, an_input: Sequence[DataSource]
+    ) -> Sequence[ExtractMetadata]:
         _LOGGER.info("Fetching extract metadata.")
-        data_sources: Sequence[Tuple[DataSourceType, DataSource]] = tuple(
-            chain.from_iterable(
-                # Map each data_source_type to tuples of the data_source_type
-                # and each of its data sources.
-                map(
-                    lambda _dst: product((_dst,), _dst.data_sources.values()),
-                    an_input,
-                )
-            )
-        )
         executor: ConcurrentExecutor[
-            Transport, Sequence[Mapping[str, ExtractMetadata]]
+            Transport, Sequence[Sequence[ExtractMetadata]]
         ] = ConcurrentExecutor(
-            *self._data_sources_to_tasks(data_sources), initial_value=list()
+            *self._data_sources_to_tasks(an_input), initial_value=list()
         )
-        executor(self._transport)  # noqa
+        extracts: Sequence[Sequence[ExtractMetadata]]
+        extracts = executor(self._transport)  # noqa
+        return tuple(chain.from_iterable(extracts))
 
     @staticmethod
     def _data_sources_to_tasks(
-        data_sources: Iterable[Tuple[DataSourceType, DataSource]]
+        data_sources: Iterable[DataSource],
     ) -> Sequence[DoFetchDataSourceExtracts]:
         return tuple(
             (
-                DoFetchDataSourceExtracts(
-                    data_source_type=_data_source[0],
-                    data_source=_data_source[1],
-                )
+                DoFetchDataSourceExtracts(data_source=_data_source)
                 for _data_source in data_sources
             )
         )

--- a/app/use_cases/main_pipeline.py
+++ b/app/use_cases/main_pipeline.py
@@ -1,15 +1,15 @@
 from typing import Any, Sequence
 
-from app.core import DataSourceType, Task, Transport
+from app.core import DataSourceType, ExtractMetadata, Task, Transport
 from app.lib import Pipeline
 
 from .fetch_metadata import FetchDataSources, FetchExtractMetadata
-from .run_extraction import ExpandDataSourceType, ExtractDataSources
+from .run_extraction import GroupSiblingExtracts, RunDataSourceExtracts
 from .types import RunExtractionResult
 
 
 class FetchMetadata(
-    Pipeline[Sequence[DataSourceType], Sequence[DataSourceType]]
+    Pipeline[Sequence[DataSourceType], Sequence[ExtractMetadata]]
 ):
     """Connect to the remote server and fetch metadata."""
 
@@ -21,12 +21,14 @@ class FetchMetadata(
 
 
 class RunExtraction(
-    Pipeline[Sequence[DataSourceType], Sequence[RunExtractionResult]]
+    Pipeline[Sequence[ExtractMetadata], Sequence[RunExtractionResult]]
 ):
-    """Extract data from a database."""
+    """
+    Run each extracts against their parent data source and return the results.
+    """
 
     def __init__(self):
-        super().__init__(ExpandDataSourceType(), ExtractDataSources())
+        super().__init__(GroupSiblingExtracts(), RunDataSourceExtracts())
 
 
 class UploadExtracts(Task[Sequence[RunExtractionResult], Any]):
@@ -39,9 +41,9 @@ class UploadExtracts(Task[Sequence[RunExtractionResult], Any]):
         # TODO: Add proper implementation.
         for _extract in an_input:
             print("==========================================================")
-            print(_extract[2].name)
+            print(_extract[0].name)
             print("==========================================================")
-            print("\n", _extract[3], "\n")
+            print("\n", _extract[1], "\n")
             print("----------------------------------------------------------")
             print("\n")
 

--- a/app/use_cases/types.py
+++ b/app/use_cases/types.py
@@ -1,7 +1,5 @@
-from typing import Any, Mapping, Tuple
+from typing import Any, Tuple
 
-from app.core import DataSource, DataSourceType, ExtractMetadata
+from app.core import ExtractMetadata
 
-AppData = Mapping[str, DataSourceType]
-
-RunExtractionResult = Tuple[DataSourceType, DataSource, ExtractMetadata, Any]
+RunExtractionResult = Tuple[ExtractMetadata, Any]


### PR DESCRIPTION
This PR builds on the work stared on #29 by refactoring the main pipeline to use the new parent accessor properties added to child domain models. This simplifies components of the main pipeline and makes it easier to read and grasp on how the pipeline works.