### PR TITLE
feat(core): add transport api for marking uploads as completed

### DIFF
--- a/app/core/transport.py
+++ b/app/core/transport.py
@@ -67,6 +67,26 @@ class Transport(Disposable, metaclass=ABCMeta):
         """
         ...
 
+    # @abstractmethod
+    def mark_upload_as_complete(
+        self, upload_metadata: UploadMetadata, **options: TransportOptions
+    ) -> None:
+        """
+        Mark the given :class:`upload metadata instance <UploadMetadata>` as
+        completed on the IDR Server. This should be called after all the chunks
+        of the given upload metadata have been uploaded successfully.
+
+        :param upload_metadata: The upload metadata instance to mark as
+            completed.
+        :param options: Optional transport options.
+
+        :return: None.
+
+        :raise TransportClosedError: If this transport is closed.
+        :raise TransportError: If an error occurs during the fetch.
+        """
+        ...
+
     @abstractmethod
     def post_upload_chunk(
         self,


### PR DESCRIPTION
Add a method on the transport interface that should mark an upload as completed.  This should be called after all the chunks of the given upload metadata have been uploaded successfully.