### PR TITLE
chore(use_cases): move upload completion to separate task

### DIFF
--- a/app/use_cases/main_pipeline.py
+++ b/app/use_cases/main_pipeline.py
@@ -6,7 +6,12 @@ from app.lib import Pipeline
 from .fetch_metadata import FetchDataSources, FetchExtractMetadata
 from .run_extraction import GroupSiblingExtracts, RunDataSourceExtracts
 from .types import RunExtractionResult
-from .upload_extracts import PostUploadChunks, PostUploads, PrepareUploads
+from .upload_extracts import (
+    MarkUploadsAsComplete,
+    PostUploadChunks,
+    PostUploads,
+    PrepareUploadChunks,
+)
 
 
 class FetchMetadata(
@@ -33,11 +38,12 @@ class RunExtraction(
 
 
 class UploadExtracts(Pipeline[Sequence[RunExtractionResult], Any]):
-    """Upload the extracted metadata to the remote server."""
+    """Upload the extracted metadata to their final destination."""
 
     def __init__(self, transport: Transport):
         super().__init__(
             PostUploads(transport=transport),
-            PrepareUploads(),
+            PrepareUploadChunks(),
             PostUploadChunks(transport=transport),
+            MarkUploadsAsComplete(transport=transport),
         )

--- a/app/use_cases/types.py
+++ b/app/use_cases/types.py
@@ -1,5 +1,7 @@
-from typing import Any, Tuple
+from typing import Any, Sequence, Tuple
 
-from app.core import ExtractMetadata
+from app.core import ExtractMetadata, UploadChunk, UploadMetadata
 
 RunExtractionResult = Tuple[ExtractMetadata, Any]
+
+UploadExtractResult = Tuple[UploadMetadata, Sequence[UploadChunk]]


### PR DESCRIPTION
Move the marking uploads as complete operation from the `PostUploadChunks` task to a new task, `MarkUploadsAsComplete`. Also rename the task `PrepareUploads` to `PrepareUploadChunks`.