### PR TITLE
chore(sql_data): encapsulate sql_data implementation

### DIFF
--- a/app/core/__init__.py
+++ b/app/core/__init__.py
@@ -8,6 +8,8 @@ from .domain import (
     UploadMetadata,
 )
 from .exceptions import (
+    DataSourceDisposedError,
+    ExtractionOperationError,
     IDRClientException,
     TransportClosedError,
     TransportError,
@@ -19,8 +21,10 @@ from .transport import Transport, TransportOptions
 __all__ = [
     "AbstractDomainObject",
     "DataSource",
+    "DataSourceDisposedError",
     "DataSourceType",
     "Disposable",
+    "ExtractionOperationError",
     "ExtractMetadata",
     "IDRClientException",
     "IdentifiableDomainObject",

--- a/app/core/domain.py
+++ b/app/core/domain.py
@@ -257,6 +257,11 @@ class DataSource(
         extract metadata instances belonging to this data source.
 
         :return: An argument to be passed to an extract metadata task.
+
+        :raise ExtractionOperationError: If an error occurs during this
+            operation.
+        :raise DataSourceDisposedError: If this method is called on a disposed
+            data source.
         """
         # TODO: Add a better API for this method.
         ...

--- a/app/core/exceptions.py
+++ b/app/core/exceptions.py
@@ -25,6 +25,31 @@ class IDRClientException(Exception):
         return self._message
 
 
+class ExtractionOperationError(IDRClientException):
+    """
+    An exception indicating that some error occurred during data extraction
+    from a ``DataSource`` or while attempting to perform operations on/against
+    a ``DataSource``.
+    """
+
+
+class DataSourceDisposedError(ExtractionOperationError):
+    """
+    An exception indicating that an erroneous usage of a disposed
+    ``DataSource`` was made.
+    """
+
+    def __init__(
+        self, message: Optional[str] = "Data source is disposed.", *args
+    ):
+        """Initialize an ``DataSourceDisposedError`` with the given parameters.
+
+        :param message: An optional error message.
+        :param args: args to pass to forward to the base exception.
+        """
+        super().__init__(message, *args)
+
+
 class TransportError(IDRClientException):
     """
     An exception indicating that some error occurred during transport of data

--- a/app/imp/sql_data/__init__.py
+++ b/app/imp/sql_data/__init__.py
@@ -6,10 +6,15 @@ from .domain import (
     SQLUploadMetadata,
     SupportedDBVendors,
 )
-from .exceptions import SQLDataError, SQLDataSourceDisposedError
+from .exceptions import (
+    SQLDataError,
+    SQLDataExtractionOperationError,
+    SQLDataSourceDisposedError,
+)
 
 __all__ = [
     "SQLDataError",
+    "SQLDataExtractionOperationError",
     "SQLDataSource",
     "SQLDataSourceDisposedError",
     "SQLDataSourceType",

--- a/app/imp/sql_data/exceptions.py
+++ b/app/imp/sql_data/exceptions.py
@@ -1,4 +1,8 @@
-from app.core import IDRClientException
+from app.core import (
+    DataSourceDisposedError,
+    ExtractionOperationError,
+    IDRClientException,
+)
 
 
 class SQLDataError(IDRClientException):
@@ -7,7 +11,16 @@ class SQLDataError(IDRClientException):
     """
 
 
-class SQLDataSourceDisposedError(SQLDataError):
+class SQLDataExtractionOperationError(SQLDataError, ExtractionOperationError):
+    """
+    An exception indicating that an error occurred while extracting data from
+    an ``SQLDataSource``.
+    """
+
+
+class SQLDataSourceDisposedError(
+    SQLDataExtractionOperationError, DataSourceDisposedError
+):
     """
     An exception indicating that a forbidden operation was attempted on a
     disposed ``SQLDataSource`` instance.

--- a/app/lib/retry/retry.py
+++ b/app/lib/retry/retry.py
@@ -129,7 +129,7 @@ class Retry:
         # Types and default values are included on the rest of the arguments to
         # quiet pyright.
         instance: Any = None,
-        args: Tuple[Any] = tuple(),
+        args: Tuple[Any, ...] = tuple(),
         kwargs: Optional[Mapping[str, Any]] = None,
     ) -> Any:
         self.load_config()

--- a/tests/lib/transports/http/test_http_transport.py
+++ b/tests/lib/transports/http/test_http_transport.py
@@ -189,7 +189,8 @@ class TestHTTPTransport(TestCase):
                 self._transport.fetch_data_source_extracts(
                     data_source_type=data_source_type, data_source=data_source
                 )
-                assert isinstance(exc_info.value.__cause__, ConnectionError)
+
+            assert isinstance(exc_info.value.__cause__, ConnectionError)
 
     def test_transport_re_authentication_failure(self) -> None:
         """
@@ -251,9 +252,8 @@ class TestHTTPTransport(TestCase):
                 self._transport.fetch_data_source_extracts(
                     data_source_type=data_source_type, data_source=data_source
                 )
-                assert isinstance(
-                    exc_info.value.__cause__, ChunkedEncodingError
-                )
+
+            assert isinstance(exc_info.value.__cause__, ChunkedEncodingError)
 
     def test_request_failure(self) -> None:
         """Assert that a request failure raises the expected errors."""


### PR DESCRIPTION
Introduce new exceptions to be raised while performing operations on/against a datasource. Then refactor the ``sql_data`` implementation to use the new errors. This should also help add retry logic at the application level and away from the ``imp`` level.