### PR TITLE
chore(use_cases): move the retry functionality to use cases

### DIFF
--- a/app/lib/retry/retry.py
+++ b/app/lib/retry/retry.py
@@ -223,7 +223,7 @@ class Retry:
                 last_exp=last_exp,
             )
             _LOGGER.debug(
-                "Retrying due to {}, sleeping for {:.1f}s ...".format(
+                'Retrying due to "{}", sleeping for {:.1f}s ...'.format(
                     last_exp, sleep
                 )
             )

--- a/app/use_cases/fetch_metadata.py
+++ b/app/use_cases/fetch_metadata.py
@@ -9,8 +9,14 @@ from app.core import (
     ExtractMetadata,
     Task,
     Transport,
+    TransportError,
 )
-from app.lib import ConcurrentExecutor, completed_successfully
+from app.lib import (
+    ConcurrentExecutor,
+    Retry,
+    completed_successfully,
+    if_exception_type_factory,
+)
 
 # =============================================================================
 # CONSTANTS
@@ -31,6 +37,7 @@ class DoFetchDataSources(Task[Transport, Sequence[DataSource]]):
     def __init__(self, data_source_type: DataSourceType):
         self._data_source_type: DataSourceType = data_source_type
 
+    @Retry(predicate=if_exception_type_factory(TransportError))
     def execute(self, an_input: Transport) -> Sequence[DataSource]:
         _LOGGER.info(
             'Fetching data sources for data source type="%s".',
@@ -52,6 +59,7 @@ class DoFetchExtractMetadata(Task[Transport, Sequence[ExtractMetadata]]):
     def __init__(self, data_source: DataSource):
         self._data_source: DataSource = data_source
 
+    @Retry(predicate=if_exception_type_factory(TransportError))
     def execute(self, an_input: Transport) -> Sequence[ExtractMetadata]:
         _LOGGER.info(
             'Fetching extract metadata for data source="%s".',


### PR DESCRIPTION
This builds on the work started on [#59](https://github.com/savannahghi/idr-client/pull/59) and [#60](https://github.com/savannahghi/idr-client/pull/60). After this refactor, all retry functionality should be moved from the ``lib`` and ``imp`` level all the way up to the application level and should help mitigate the scattering of the retry functionality all over the codebase.